### PR TITLE
link to planetos web page

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -49,7 +49,9 @@ under the License.
     </a>
     <div class="tocify-wrapper">
       <div class="logo-wrapper">
+      <a href="https://planetos.com/">
         <%= image_tag "http://data.planetos.com/userland/img/planetos-logo.svg" %>
+      </a>
       </div>
       <% if language_tabs %>
         <div class="lang-selector">


### PR DESCRIPTION
sometimes when you are reading docs, it might be useful to have a link to the root (organization).
In this way also https://planetos.com/ is done (if you click on the icon - you are re-directed back to the home page).
